### PR TITLE
[Feature] Create a simple file share

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ Cargo.lock
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Added by cargo
+
+/target

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ Cargo.lock
 # Added by cargo
 
 /target
+received_file

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "RustShare"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "RustShare"
+name = "rust_share"  # Modifica il nome del crate in snake case
 version = "0.1.0"
 edition = "2021"
 

--- a/received/README.md
+++ b/received/README.md
@@ -1,0 +1,2 @@
+# RustShare
+A system to share files between devices in the same network

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,0 +1,1 @@
+pub const PORT: u16 = 7878;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,15 @@
-fn main() {
-    println!("Hello, world!");
+use std::env;
+use std::io;
+mod sender;
+mod receiver;
+mod common;
+
+fn main() -> io::Result<()> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() == 4 && args[1] == "send" {
+        sender::send_file(&args[2], &args[3])?;
+    } else {
+        receiver::receive_file()?;
+    }
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,12 @@ mod sender;
 mod receiver;
 mod common;
 
+fn print_usage() {
+    println!("Usage:");
+    println!("  send <address> <file_path> - Send a file to the specified address");
+    println!("  receive - Receive files on the specified port");
+}
+
 fn main() -> io::Result<()> {
     let args: Vec<String> = env::args().collect();
     if args.len() == 4 && args[1] == "send" {

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -1,35 +1,46 @@
-use std::{fs::File, io::{self, Read, Write}, net::{TcpListener, TcpStream}, thread};
+use std::{fs::{self, File}, io::{self, BufRead, BufReader, Read, Write}, net::{TcpListener, TcpStream}, thread};
 use crate::common::PORT;
 
 fn handle_client(mut stream: TcpStream) -> io::Result<()> {
-    println!("Connessione ricevuta");
-    let mut file = File::create("received_file")?;
+    println!("Connection received");
+
+    // Read the file name
+    let mut reader = BufReader::new(&mut stream);
+    let mut file_name = String::new();
+    reader.read_line(&mut file_name)?;
+    let file_name = file_name.trim();
+
+    // Create the "received" directory if it doesn't exist
+    fs::create_dir_all("received")?;
+
+    let file_path = format!("received/{}", file_name);
+    let mut file = File::create(file_path)?;
     let mut buffer = [0; 1024];
 
-    while let Ok(n) = stream.read(&mut buffer) {
+    while let Ok(n) = reader.read(&mut buffer) {
         if n == 0 {
             break;
         }
         file.write_all(&buffer[..n])?;
     }
-    println!("File ricevuto e salvato come 'received_file'");
+    println!("File received and saved as 'received/{}'", file_name);
     Ok(())
 }
 
 pub fn receive_file() -> io::Result<()> {
     let listener = TcpListener::bind(format!("0.0.0.0:{}", PORT))?;
-    println!("In ascolto sulla porta {}", PORT);
+    println!("Listening on port {}", PORT);
 
     for stream in listener.incoming() {
         match stream {
             Ok(stream) => {
                 thread::spawn(move || {
                     if let Err(e) = handle_client(stream) {
-                        eprintln!("Errore nel gestire il client: {}", e);
+                        eprintln!("Error handling client: {}", e);
                     }
                 });
             },
-            Err(e) => eprintln!("Errore durante la connessione: {}", e),
+            Err(e) => eprintln!("Connection error: {}", e),
         }
     }
     Ok(())

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -1,0 +1,36 @@
+use std::{fs::File, io::{self, Read, Write}, net::{TcpListener, TcpStream}, thread};
+use crate::common::PORT;
+
+fn handle_client(mut stream: TcpStream) -> io::Result<()> {
+    println!("Connessione ricevuta");
+    let mut file = File::create("received_file")?;
+    let mut buffer = [0; 1024];
+
+    while let Ok(n) = stream.read(&mut buffer) {
+        if n == 0 {
+            break;
+        }
+        file.write_all(&buffer[..n])?;
+    }
+    println!("File ricevuto e salvato come 'received_file'");
+    Ok(())
+}
+
+pub fn receive_file() -> io::Result<()> {
+    let listener = TcpListener::bind(format!("0.0.0.0:{}", PORT))?;
+    println!("In ascolto sulla porta {}", PORT);
+
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                thread::spawn(move || {
+                    if let Err(e) = handle_client(stream) {
+                        eprintln!("Errore nel gestire il client: {}", e);
+                    }
+                });
+            },
+            Err(e) => eprintln!("Errore durante la connessione: {}", e),
+        }
+    }
+    Ok(())
+}

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -1,9 +1,19 @@
-use std::{fs::File, io::{self, Read, Write}, net::{TcpStream, Shutdown}};
+use std::{fs::File, io::{self, Read, Write}, net::{TcpStream, Shutdown}, path::Path};
 
 pub fn send_file(addr: &str, file_path: &str) -> io::Result<()> {
     let mut stream = TcpStream::connect(addr)?;
     let mut file = File::open(file_path)?;
     let mut buffer = [0; 1024];
+
+    // Get the file name from the file_path
+    let file_name = Path::new(file_path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "Invalid file name"))?;
+
+    // Send the file name
+    stream.write_all(file_name.as_bytes())?;
+    stream.write_all(b"\n")?;
 
     while let Ok(n) = file.read(&mut buffer) {
         if n == 0 {
@@ -13,6 +23,6 @@ pub fn send_file(addr: &str, file_path: &str) -> io::Result<()> {
     }
 
     stream.shutdown(Shutdown::Write)?;
-    println!("File inviato con successo a {}", addr);
+    println!("File successfully sent to {}", addr);
     Ok(())
 }

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -1,0 +1,18 @@
+use std::{fs::File, io::{self, Read, Write}, net::{TcpStream, Shutdown}};
+
+pub fn send_file(addr: &str, file_path: &str) -> io::Result<()> {
+    let mut stream = TcpStream::connect(addr)?;
+    let mut file = File::open(file_path)?;
+    let mut buffer = [0; 1024];
+
+    while let Ok(n) = file.read(&mut buffer) {
+        if n == 0 {
+            break;
+        }
+        stream.write_all(&buffer[..n])?;
+    }
+
+    stream.shutdown(Shutdown::Write)?;
+    println!("File inviato con successo a {}", addr);
+    Ok(())
+}


### PR DESCRIPTION
With this version of the program, it's possible to send and receive files. 

in particular, starting with "receive" argument, the program listens on a specific port (actually hardcoded) to receive files from other clients. Starting instead with a "send" argument the target host and port must be specified together with a file path to be sent. 
This file is then sent and the receiver will store it in the "received" sub directory. 